### PR TITLE
Update to .NET 10 and upgrade dependencies

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        dotnet-version: ['9.0']
+        dotnet-version: ['10.0']
     defaults:
        run:
          working-directory: .
@@ -25,7 +25,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9'
+        dotnet-version: '10'
 
     - name: Restore dependencies
       run:  dotnet restore

--- a/.github/workflows/buildPackAndPush.yml
+++ b/.github/workflows/buildPackAndPush.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        dotnet-version: ['9.0']
+        dotnet-version: ['10.0']
     defaults:
        run:
          working-directory: .
@@ -26,7 +26,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9'
+        dotnet-version: '10'
 
     - name: Restore dependencies
       run:  dotnet restore

--- a/AutoInject.Test.Library/AutoInject.Test.Library.csproj
+++ b/AutoInject.Test.Library/AutoInject.Test.Library.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/AutoInject.Test.Library2/AutoInject.SecondAssemblyTest.Library.csproj
+++ b/AutoInject.Test.Library2/AutoInject.SecondAssemblyTest.Library.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/AutoInject.Tests/AutoInject.Tests.csproj
+++ b/AutoInject.Tests/AutoInject.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/AutoInject/AutoInject.csproj
+++ b/AutoInject/AutoInject.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.8.2</Version>
-    <TargetFramework>net9.0</TargetFramework>
+    <Version>1.9.0</Version>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -14,7 +14,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageId>AutoInjectRegister</PackageId>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <PackageReleaseNotes>Minor change to use return yield and reversed order to not need stack.</PackageReleaseNotes>
+    <PackageReleaseNotes>Support for .net 10</PackageReleaseNotes>
   </PropertyGroup>  
   
   <ItemGroup>    


### PR DESCRIPTION
Bump target framework to net10.0 across all projects and update related GitHub Actions workflows to use .NET 10. Also upgrade test dependencies and increment package version to 1.9.0 with updated release notes indicating .NET 10 support.